### PR TITLE
docs: setup guide for docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ config.json 默认配置如下：
 
 `outputPath` 如果不填写，默认为 `syncPath` 下的 output 文件夹。
 
+你还可以使用Docker进行部署，参见[使用Docker部署简悦同步助手 · 命令行](https://github.com/Kenshin/simpread/discussions/4312)
 ## 如何更新
 
 使用 `./simpread-sync -V` 来检查当前版本。（如有更新则会自动提示）

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,13 @@ services:
   simpread-sync:
     image: ghcr.io/j1g5awi/simpread-sync:master
     container_name: simpread-sync
-    restart: always
-    ports:
-      - '7026:7026'
-    volumes:
-      - ~/simpread:/data
     environment:
-      SYNC_PATH: /data
-      OUTPUT_PATH_MD: ""
+      - TZ=Asia/Shanghai
+      - SYNC_PATH=/data
+      - OUTPUT_PATH=/data/output
+    ports:
+      - 7026:7026
+    volumes:
+      - ./data:/data
+      - ./output:/data/output
+    restart: unless-stopped


### PR DESCRIPTION
- 在`README.MD`中添加了我撰写的https://github.com/Kenshin/simpread/discussions/4312 的链接
- 完善仓库提供的`docker-compose.yml`模板:
  - 默认设置容器时区为`Asia/Shanghai`
  - ~默认映射SMTP服务端口`465`~
  - 使用相对路径分别 bind mount `SYNC_PATH`与`OUTPUT_PATH`
    > 由于 docker 容器的启动需要 root 权限，模板原有的 bind mount 目的地 `~/simpread` 实际指向的是`/root/simpread`，会有权限问题
  - 修改容器重启策略为`unless-stopped`