### PR TITLE
fix: http client ignore tls verify

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ var (
 var tr = &http.Transport{
 	TLSClientConfig:    &tls.Config{InsecureSkipVerify: true},
 }
-var client := &http.Client{Transport: tr}
+var client = &http.Client{Transport: tr}
 
 var rootCmd = &cobra.Command{
 	Use: "simpread-sync",

--- a/main.go
+++ b/main.go
@@ -46,6 +46,11 @@ var (
 	uid            string
 )
 
+var tr := &http.Transport{
+	TLSClientConfig:    &tls.Config{InsecureSkipVerify: true},
+}
+var client := &http.Client{Transport: tr}
+
 var rootCmd = &cobra.Command{
 	Use: "simpread-sync",
 	PreRun: func(cmd *cobra.Command, args []string) {
@@ -859,7 +864,7 @@ func textbundleHandle(w http.ResponseWriter, r *http.Request) {
 				go func(i int, image string) {
 					image = matchReplace.ReplaceAllString(image, "")
 
-					resp, err := http.Get(image)
+					resp, err := client.Get(image)
 					if err != nil {
 						log.Println(err)
 						return

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/md5"
+	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -46,7 +47,7 @@ var (
 	uid            string
 )
 
-var tr := &http.Transport{
+var tr = &http.Transport{
 	TLSClientConfig:    &tls.Config{InsecureSkipVerify: true},
 }
 var client := &http.Client{Transport: tr}


### PR DESCRIPTION
use http.Client to skip verify